### PR TITLE
Update swap.css

### DIFF
--- a/icons/css/swap.css
+++ b/icons/css/swap.css
@@ -25,7 +25,7 @@
 .gg-swap::before {
     border-left: 3px solid;
     top: -4px;
-    right: -4px
+    right: -7px
 }
 
 .gg-swap::after {


### PR DESCRIPTION
[https://i.imgur.com/Asg8NgM.png](https://i.imgur.com/Asg8NgM.png)

.gg-swap::before {
right: -4px; // Not pulled enough to the right. It needs -7px to look right, but maybe there's a different approach to fix this issue
}

.gg-swap::before {
right: -7px;
}